### PR TITLE
Fix expression typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Sum digits to 100 -- 1962 SciAm Mathematical Games solver recreation
 
 Solution to Problem 8 in Mathematical Games, Scientific American, Oct. 1962:
 "the problem of inserting mathematical signs wherever one likes between the digits
-1, 2, 3, 4, 5, 6, 7, 8, 9 to make the ex­pression equal 100". And also the problem
+1, 2, 3, 4, 5, 6, 7, 8, 9 to make the expression equal 100". And also the problem
 with the digits in reverse.
 
 The output matches that given by Mark Resnick in his letter to the editor, Jan. 1963,

--- a/sum100c.cpp
+++ b/sum100c.cpp
@@ -3,7 +3,7 @@
 //
 // Solution to Problem 8 in Mathematical Games, Scientific American, Oct. 1962:
 // "the problem of inserting mathematical signs wherever one likes between the digits
-// 1, 2, 3, 4, 5, 6, 7, 8, 9 to make the ex­pression equal 100". And also the problem
+// 1, 2, 3, 4, 5, 6, 7, 8, 9 to make the expression equal 100". And also the problem
 // with the digits in reverse.
 //
 // The output matches that given by Mark Resnick in his letter to the editor, Jan. 1963,

--- a/sum100r.rs
+++ b/sum100r.rs
@@ -3,7 +3,7 @@
 //
 // Solution to Problem 8 in Mathematical Games, Scientific American, Oct. 1962:
 // "the problem of inserting mathematical signs wherever one likes between the digits
-// 1, 2, 3, 4, 5, 6, 7, 8, 9 to make the ex­pression equal 100". And also the problem
+// 1, 2, 3, 4, 5, 6, 7, 8, 9 to make the expression equal 100". And also the problem
 // with the digits in reverse.
 //
 // The output matches that given by Mark Resnick in his letter to the editor, Jan. 1963,

--- a/sum100s.swift
+++ b/sum100s.swift
@@ -5,7 +5,7 @@
 //
 // Solution to Problem 8 in Mathematical Games, Scientific American, Oct. 1962:
 // "the problem of inserting mathematical signs wherever one likes between the digits
-// 1, 2, 3, 4, 5, 6, 7, 8, 9 to make the ex­pression equal 100". And also the problem
+// 1, 2, 3, 4, 5, 6, 7, 8, 9 to make the expression equal 100". And also the problem
 // with the digits in reverse.
 //
 // The output matches that given by Mark Resnick in his letter to the editor, Jan. 1963,


### PR DESCRIPTION
## Summary
- replace soft hyphen `ex­pression` with plain `expression`

## Testing
- `make` *(fails: `sort` is not a member of `std`)*

------
https://chatgpt.com/codex/tasks/task_e_68438d7a29f48332aac951c964763f58